### PR TITLE
Fix JS highlighting inside HTML <script> tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const prismCore = 'prismjs/components/prism-core';
 const Prism = require(prismCore);
 
 const prelude = [
-  'prism-clike', 'prism-javascript', 'prism-markup',
+  'prism-clike', 'prism-markup', 'prism-javascript',
   'prism-c', 'prism-ruby', 'prism-css',
 ];
 const prismComponents = path.dirname(require.resolve(prismCore));


### PR DESCRIPTION
The prism-javascript module extends the prism-markup module to enable
highlighting JS inside <script> tags, but the markup module must already
be available to do so.